### PR TITLE
Fix README env instructions and add sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ cd smart-retention
 
 #### Setup
 
+Copie o arquivo `.env.development.example` para `.env.development` e ajuste as variáveis do banco.
+
 ```bash
 cd backend
-cp .env.development.example .env.development        # configure o banco
+cp .env.development.example .env.development
 go mod tidy
 go run main.go              # inicia a API
 ```
@@ -51,9 +53,10 @@ go run main.go              # inicia a API
 
 #### Setup
 
+Crie um arquivo `.env.development` com a variável `VITE_API_URL` apontando para o backend.
+
 ```bash
 cd frontend
-cp .env.development.example .env.development        # configure a URL do backend
 npm install
 npm run dev
 ```

--- a/backend/.env.development.example
+++ b/backend/.env.development.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_USER=user
+DB_PASSWORD=password
+DB_NAME=smart_db
+DB_PORT=5432


### PR DESCRIPTION
## Summary
- add `.env.development.example` with placeholder DB settings
- clarify backend setup instructions
- explain how to configure frontend environment variables

## Testing
- `gofmt -w backend/internal/infra/db/db.go`


------
https://chatgpt.com/codex/tasks/task_e_68507f07d140832281cd0615292867b1